### PR TITLE
add delegate call

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -67,7 +67,7 @@ mod cross_contract_flipper {
 
         // Delegate calls `flip` method of the other contract
         #[ink(message)]
-        pub fn inc_delegate(&mut self) {
+        pub fn flip_delegate(&mut self) {
             let selector = ink::selector_bytes!("flip");
             let _ = build_call::<DefaultEnvironment>()
                 .delegate(self.delegate_to())

--- a/lib.rs
+++ b/lib.rs
@@ -17,170 +17,78 @@
 
 #[ink::contract]
 mod cross_contract_flipper {
-    /// The global call builder type for an ink! trait definition.
-    /// Allows us to use call_mut() which is a method of TraitCallBuilder
-    /// that returns an exclusive reference to the global call builder type.
-    use ink::codegen::TraitCallBuilder;
 
-    use ink::env::{
-        call::{build_call, build_create, ExecutionInput, Selector},
-        DefaultEnvironment,
+    use ink::{
+        env::{
+            call::{
+                build_call,
+                ExecutionInput,
+                Selector,
+            },
+            CallFlags,
+            DefaultEnvironment,
+        },
+        storage::{
+            Lazy,
+        },
     };
-
-    use other_contract::OtherContractRef;
 
     #[ink(storage)]
     pub struct CrossContractFlipper {
-        other_contract: OtherContractRef,
-        other_contract_code_hash: Hash,
+        value: bool,
+        delegate_to: Lazy<Hash>,
     }
 
     impl CrossContractFlipper {
         /// Initializes a contract by specifying the code hash of the other contract
         #[ink(constructor)]
-        pub fn new(other_contract_code_hash: Hash) -> Self {
-            let other_contract = OtherContractRef::new(true)
-                .code_hash(other_contract_code_hash)
-                // Amount transferred upon the execution of this call (instantiation).
-                .endowment(0)
-                // The salt for determining the hash for the contract account ID.
-                // Use to create multiple instances of the same contract code from the same account.
-                .salt_bytes([0xDE, 0xAD, 0xBE, 0xEF])
-                .instantiate();
+        pub fn new(init_value: bool, code_hash: Hash) -> Self {
+
+            // Initialize the hash of the contract to delegate to.
+            // Adds a delegate dependency lock, ensuring that the delegated to code cannot
+            // be removed.
+            let mut delegate_to = Lazy::new();
+            delegate_to.set(&code_hash);
+
+            Self::env().lock_delegate_dependency(&code_hash);
 
             Self {
-                other_contract,
-                other_contract_code_hash,
+                value: init_value,
+                delegate_to
             }
-        }
-
-        /// Initializes a contract by specifying the code hash of the other contract
-        /// using the create builder API
-        /// https://docs.rs/ink_env/5.0.0/ink_env/call/struct.CreateBuilder.html
-        #[ink(constructor)]
-        pub fn new_with_create_builder(other_contract_code_hash: Hash) -> Self {
-            let other_contract: OtherContractRef = build_create::<OtherContractRef>()
-                .code_hash(other_contract_code_hash)
-                .endowment(0)
-                .exec_input(
-                    ExecutionInput::new(Selector::new(ink::selector_bytes!("new"))).push_arg(true),
-                )
-                .salt_bytes(&[0xDE, 0xAD, 0xBE, 0xEF])
-                .returns::<OtherContractRef>()
-                .instantiate();
-
-            Self {
-                other_contract,
-                other_contract_code_hash,
-            }
-        }
-
-        /// Calls the `flip` method of the other contract
-        /// using the call builder API
-        /// https://docs.rs/ink_env/5.0.0/ink_env/call/struct.CallBuilder.html
-        #[ink(message)]
-        pub fn build_call_flip_1(&mut self) {
-            build_call::<DefaultEnvironment>()
-                .call(self.get_other_contract_account_id())
-                // Amount of funds that are transferred to the other contract with this call.
-                .transferred_value(0)
-                .exec_input(ExecutionInput::new(Selector::new(ink::selector_bytes!(
-                    "flip"
-                ))))
-                .returns::<()>()
-                .invoke();
-        }
-
-        /// Calls the `flip` method of another contract dynamically
-        /// using the call builder API and specifying the account ID of the other contract
-        /// https://docs.rs/ink_env/5.0.0/ink_env/call/struct.CallBuilder.html
-        #[ink(message)]
-        pub fn build_call_flip_2(&mut self, other_contract_account_id: AccountId) {
-            build_call::<DefaultEnvironment>()
-                .call(other_contract_account_id)
-                .transferred_value(0)
-                .exec_input(ExecutionInput::new(Selector::new(ink::selector_bytes!(
-                    "flip"
-                ))))
-                .returns::<()>()
-                .invoke();
-        }
-
-        /// Calls `flip` method of the other contract
-        /// without specifying the weight and storage limits
-        #[ink(message)]
-        pub fn call_flip(&mut self) {
-            self.other_contract.flip();
-        }
-
-        /// Calls `set` method of the other contract
-        /// without specifying the weight and storage limits
-        #[ink(message)]
-        pub fn call_set(&mut self) {
-            self.other_contract.set(true);
         }
 
         /// Calls `get` method of the other contract
         /// without specifying the weight and storage limits
         #[ink(message)]
-        pub fn call_get(&mut self) -> bool {
-            self.other_contract.get()
-        }
-
-        /// Calls the `flip` method of the other contract
-        /// with the specified weight and storage limits
-        #[ink(message)]
-        pub fn call_flip_with_limits(
-            &mut self,
-            ref_time_limit: u64,
-            proof_size_limit: u64,
-            storage_deposit_limit: Balance,
-        ) {
-            self.other_contract
-                .call_mut()
-                .flip()
-                .ref_time_limit(ref_time_limit)
-                .proof_size_limit(proof_size_limit)
-                .storage_deposit_limit(storage_deposit_limit)
-                .invoke();
-        }
-
-        /// Calls the `get` method of the other contract
-        /// with the specified weight and storage limits
-        #[ink(message)]
-        pub fn call_get_with_limits(
-            &mut self,
-            ref_time_limit: u64,
-            proof_size_limit: u64,
-            storage_deposit_limit: Balance,
-        ) -> bool {
-            self.other_contract
-                .call_mut()
-                .get()
-                .ref_time_limit(ref_time_limit)
-                .proof_size_limit(proof_size_limit)
-                .storage_deposit_limit(storage_deposit_limit)
-                .invoke()
-        }
-
-        /// Calls `get_account_id` method of the other contract
-        /// without specifying the weight and storage limits
-        #[ink(message)]
-        pub fn get_other_contract_account_id(&mut self) -> AccountId {
-            self.other_contract.get_account_id()
+        pub fn get_value(&mut self) -> bool {
+            self.value
         }
 
         // Delegate calls `flip` method of the other contract
-        // using `DelegateCall` method of the call builder API
-        // https://docs.rs/ink_env/5.0.0/ink_env/call/struct.DelegateCall.html
-        // https://docs.rs/ink_env/5.0.0/ink_env/call/fn.build_call.html#example-3-delegate-call
-        // https://medium.com/coinmonks/delegatecall-calling-another-contract-function-in-solidity-b579f804178c
         #[ink(message)]
-        pub fn delegate_flip(&mut self) {
-            // Bonus Exercise: Delegate call to the other contract
-            // Submit a PR to this repo when completed
-            // Include steps to test the delegate call, even better would be e2e tests ;)
-            todo!()
+        pub fn inc_delegate(&mut self) {
+            let selector = ink::selector_bytes!("flip");
+            let _ = build_call::<DefaultEnvironment>()
+                .delegate(self.delegate_to())
+                // We specify `CallFlags::TAIL_CALL` to use the delegatee last memory frame
+                // as the end of the execution cycle.
+                // So any mutations to `Packed` types, made by delegatee,
+                // will be flushed to storage.
+                //
+                // If we don't specify this flag.
+                // The storage state before the delegate call will be flushed to storage instead.
+                // See https://substrate.stackexchange.com/questions/3336/i-found-set-allow-reentry-may-have-some-problems/3352#3352
+                .call_flags(CallFlags::TAIL_CALL)
+                .exec_input(ExecutionInput::new(Selector::new(selector)))
+                .returns::<()>()
+                .try_invoke();
+        }
+
+        fn delegate_to(&self) -> Hash {
+            self.delegate_to
+                .get()
+                .expect("delegate_to always has a value")
         }
     }
 }


### PR DESCRIPTION
This is an example.

As noted here:
- https://github.com/use-ink/ink-examples/tree/682605fb39f4d9a2d69a48ffc0ce042602386ad9/upgradeable-contracts#delegator

```
cd other_contract
# only upload other_contract
pop up contract -u
```
Copy the code hash.
```
cd ..
pop up contract --args false, <OTHER_CONTRACT_CODE_HASH>
pop call contract --contract <CROSS_CONTRACT_FLIPPER_ADDRESS> --message get_value
pop call contract --contract <CROSS_CONTRACT_FLIPPER_ADDRESS> --message inc_delegate --execute
pop call contract --contract <CROSS_CONTRACT_FLIPPER_ADDRESS> --message get_value
```
